### PR TITLE
Optimize override route filtering

### DIFF
--- a/EveMarketProphet/Services/Map.cs
+++ b/EveMarketProphet/Services/Map.cs
@@ -42,10 +42,9 @@ namespace EveMarketProphet.Services
             return graph;
         }
 
-        public List<int> FindRoute(int startSolarSystemId, int endSolarSystemId)
+        public List<int> FindRoute(int startSolarSystemId, int endSolarSystemId, bool isHighSec)
         {
             var route = new List<int>();
-            var isHighSec = Properties.Settings.Default.IsHighSec;
 
             // return empty list for inner-solarsystem trade
             if (startSolarSystemId == endSolarSystemId) return route;

--- a/EveMarketProphet/Services/Prophet.cs
+++ b/EveMarketProphet/Services/Prophet.cs
@@ -8,14 +8,23 @@ using EveMarketProphet.Properties;
 
 namespace EveMarketProphet.Services
 {
+    public class ProphetSearchOptions
+    {
+        public int? StartSystemIdOverride { get; set; }
+        public int? DestinationSystemIdFilter { get; set; }
+        public bool IgnoreSettings { get; set; }
+        public ISet<(int StartSystemId, int EndSystemId)> ExcludedSystemPairs { get; set; }
+        public double? MinimumProfitPerJumpOverride { get; set; }
+    }
+
     public static class Prophet
     {
+        private const double OverrideProfitPerJumpFloor = 15000d;
         private static readonly ConcurrentDictionary<(int Start, int End, bool HighSec), List<int>> RouteCache = new ConcurrentDictionary<(int Start, int End, bool HighSec), List<int>>();
         private static readonly ConcurrentDictionary<(int Start, int End, bool HighSec), byte> UnreachableRoutes = new ConcurrentDictionary<(int Start, int End, bool HighSec), byte>();
 
-        private static List<int> GetRoute(int startSystemId, int endSystemId)
+        private static List<int> GetRoute(int startSystemId, int endSystemId, bool isHighSec)
         {
-            var isHighSec = Settings.Default.IsHighSec;
             var key = (startSystemId, endSystemId, isHighSec);
 
             if (UnreachableRoutes.ContainsKey(key))
@@ -28,7 +37,7 @@ namespace EveMarketProphet.Services
                 return cached;
             }
 
-            var route = Map.Instance.FindRoute(startSystemId, endSystemId);
+            var route = Map.Instance.FindRoute(startSystemId, endSystemId, isHighSec);
             if (route == null)
             {
                 UnreachableRoutes.TryAdd(key, 0);
@@ -41,6 +50,13 @@ namespace EveMarketProphet.Services
 
         public static List<Trip> FindTradeRoutes()
         {
+            return FindTradeRoutes(new ProphetSearchOptions());
+        }
+
+        public static List<Trip> FindTradeRoutes(ProphetSearchOptions options)
+        {
+            options ??= new ProphetSearchOptions();
+
             if (Market.Instance.OrdersByType == null) return null;
             if (Market.Instance.OrdersByType.Count == 0) return null;
 
@@ -48,6 +64,30 @@ namespace EveMarketProphet.Services
             var typesById = db.TypesById;
             var stationsById = db.StationsById;
             var solarSystemsById = db.SolarSystemsById;
+
+            var ignoreSettings = options.IgnoreSettings;
+            var minBaseProfit = ignoreSettings ? 0 : Settings.Default.MinBaseProfit;
+            var minProfitPerJump = options.MinimumProfitPerJumpOverride ?? (ignoreSettings ? OverrideProfitPerJumpFloor : Settings.Default.MinProfitPerJump);
+
+            var startSystemOverride = options.StartSystemIdOverride;
+            var destinationSystemFilter = options.DestinationSystemIdFilter;
+            var excludedPairs = options.ExcludedSystemPairs;
+
+            var hasStartFilter = startSystemOverride.HasValue;
+            var hasDestinationFilter = destinationSystemFilter.HasValue;
+            var hasExcludedPairs = excludedPairs != null && excludedPairs.Count > 0;
+            var startSystemFilterId = startSystemOverride.GetValueOrDefault();
+            var destinationSystemFilterId = destinationSystemFilter.GetValueOrDefault();
+
+            if (ignoreSettings && minProfitPerJump < OverrideProfitPerJumpFloor)
+            {
+                minProfitPerJump = OverrideProfitPerJumpFloor;
+            }
+
+            var minFillerProfit = ignoreSettings ? 0 : Settings.Default.MinFillerProfit;
+            var capital = ignoreSettings ? long.MaxValue : Settings.Default.Capital;
+            var maxCargo = ignoreSettings ? double.MaxValue : Settings.Default.MaxCargo;
+            var requireHighSec = !ignoreSettings && Settings.Default.IsHighSec;
 
             var profitableTx = new ConcurrentBag<Transaction>();
 
@@ -72,17 +112,26 @@ namespace EveMarketProphet.Services
 
                 foreach (var sellOrder in sellOrders)
                 {
+                    if (hasStartFilter && sellOrder.SystemId != startSystemFilterId)
+                        continue;
+
                     foreach (var buyOrder in buyOrders)
                     {
+                        if (hasDestinationFilter && buyOrder.SystemId != destinationSystemFilterId)
+                            continue;
+
+                        if (hasExcludedPairs && excludedPairs.Contains((sellOrder.SystemId, buyOrder.SystemId)))
+                            continue;
+
                         if (sellOrder.Price >= buyOrder.Price)
                             break;
 
                         var tx = new Transaction(sellOrder, buyOrder);
 
-                        if (Settings.Default.IsHighSec && tx.SellOrder.StationSecurity < 0.5)
+                        if (requireHighSec && tx.SellOrder.StationSecurity < 0.5)
                             continue;
 
-                        if (tx.Profit < Settings.Default.MinBaseProfit)
+                        if (tx.Profit < minBaseProfit)
                             continue;
 
                         profitableTx.Add(tx);
@@ -93,13 +142,28 @@ namespace EveMarketProphet.Services
             if (profitableTx.IsEmpty)
                 return null;
 
-            var playerSystemId = Auth.Instance.GetLocation();
+            var playerSystemId = startSystemOverride ?? Auth.Instance.GetLocation();
             if (playerSystemId == 0)
                 playerSystemId = Settings.Default.DefaultLocation;
 
             var stationPairGroups = profitableTx
                 .GroupBy(x => new { x.StartStationId, x.EndStationId })
-                .Select(group => group.OrderByDescending(x => x.Profit).ToList());
+                .Select(group => group.OrderByDescending(x => x.Profit).ToList())
+                .Where(group =>
+                {
+                    var firstTx = group.First();
+
+                    if (hasStartFilter && firstTx.StartSystemId != startSystemFilterId)
+                        return false;
+
+                    if (hasDestinationFilter && firstTx.EndSystemId != destinationSystemFilterId)
+                        return false;
+
+                    if (hasExcludedPairs && excludedPairs.Contains((firstTx.StartSystemId, firstTx.EndSystemId)))
+                        return false;
+
+                    return true;
+                });
 
             var trips = new ConcurrentBag<Trip>();
 
@@ -107,36 +171,36 @@ namespace EveMarketProphet.Services
             {
                 var selectedTx = new List<Transaction>();
                 var firstTx = txGroup.First();
-                var waypoints = GetRoute(firstTx.StartSystemId, firstTx.EndSystemId);
+                var waypoints = GetRoute(firstTx.StartSystemId, firstTx.EndSystemId, requireHighSec);
 
                 if (waypoints == null)
                     return;
 
-                var isk = Settings.Default.Capital;
-                var vol = Settings.Default.MaxCargo;
+                var isk = capital;
+                var vol = maxCargo;
 
-                var types = txGroup.GroupBy(x => x.TypeId).Select(x => x.Key);
-
-                foreach (var typeId in types)
+                foreach (var typeGroup in txGroup.GroupBy(x => x.TypeId))
                 {
-                    var buyOrders = txGroup.Where(x => x.TypeId == typeId)
+                    var buyOrders = typeGroup
                         .Select(x => x.BuyOrder)
+                        .Where(o => !hasDestinationFilter || o.SystemId == destinationSystemFilterId)
                         .OrderByDescending(x => x.Price)
                         .GroupBy(x => x.OrderId)
                         .Select(x => x.First())
                         .ToList();
 
-                    var sellOrders = txGroup.Where(x => x.TypeId == typeId)
+                    var sellOrders = typeGroup
                         .Select(x => x.SellOrder)
+                        .Where(o => !hasStartFilter || o.SystemId == startSystemFilterId)
                         .OrderBy(x => x.Price)
                         .GroupBy(x => x.OrderId)
                         .Select(x => x.First())
                         .ToList();
 
-                    var tracker = sellOrders
-                        .GroupBy(x => x.OrderId)
-                        .Select(x => x.First())
-                        .ToDictionary(x => x.OrderId, x => x.VolumeRemaining);
+                    if (buyOrders.Count == 0 || sellOrders.Count == 0)
+                        continue;
+
+                    var tracker = sellOrders.ToDictionary(x => x.OrderId, x => x.VolumeRemaining);
 
                     foreach (var buyOrder in buyOrders)
                     {
@@ -145,6 +209,9 @@ namespace EveMarketProphet.Services
 
                         foreach (var sellOrder in sellOrders)
                         {
+                            if (hasExcludedPairs && excludedPairs.Contains((sellOrder.SystemId, buyOrder.SystemId)))
+                                continue;
+
                             if (tracker[sellOrder.OrderId] <= 0)
                                 continue;
 
@@ -161,7 +228,7 @@ namespace EveMarketProphet.Services
                                 ? partialTx.Profit / (double)partialTx.Jumps
                                 : partialTx.Profit;
 
-                            if (partialTx.ProfitPerJump < Settings.Default.MinProfitPerJump)
+                            if (partialTx.ProfitPerJump < minProfitPerJump)
                                 continue;
 
                             if (partialTx.Cost <= isk && partialTx.Weight <= vol)
@@ -173,7 +240,12 @@ namespace EveMarketProphet.Services
                             }
                             else
                             {
-                                var quantityIsk = sellOrder.Price > 0 ? (int)(isk / sellOrder.Price) : 0;
+                                var quantityIsk = 0;
+                                if (sellOrder.Price > 0)
+                                {
+                                    var maxAffordable = isk / sellOrder.Price;
+                                    quantityIsk = (int)System.Math.Min(int.MaxValue, maxAffordable);
+                                }
                                 var quantityWeight = sellOrder.TypeVolume > 0 ? (int)(vol / sellOrder.TypeVolume) : 0;
                                 var quantityPart = Math.Min(quantityIsk, quantityWeight);
 
@@ -188,10 +260,10 @@ namespace EveMarketProphet.Services
                                         ? partTx.Profit / (double)partTx.Jumps
                                         : partTx.Profit;
 
-                                    if (partTx.ProfitPerJump < Settings.Default.MinProfitPerJump)
+                                    if (partTx.ProfitPerJump < minProfitPerJump)
                                         continue;
 
-                                    if (partTx.Profit > Settings.Default.MinFillerProfit)
+                                    if (partTx.Profit > minFillerProfit)
                                     {
                                         quantityToFill -= partTx.Quantity;
                                         isk -= partTx.Cost;
@@ -235,7 +307,7 @@ namespace EveMarketProphet.Services
                         Weight = selectedTx.Sum(x => x.Weight)
                     };
 
-                    var approachRoute = GetRoute(playerSystemId, trip.Transactions.First().StartSystemId);
+                    var approachRoute = GetRoute(playerSystemId, trip.Transactions.First().StartSystemId, requireHighSec);
                     if (approachRoute != null)
                     {
                         trip.Waypoints = approachRoute;
@@ -261,7 +333,7 @@ namespace EveMarketProphet.Services
                             }
                         }
 
-                        if (trip.ProfitPerJump >= Settings.Default.MinProfitPerJump)
+                        if (trip.ProfitPerJump >= minProfitPerJump)
                         {
                             trips.Add(trip);
                         }

--- a/EveMarketProphet/ViewModels/MainViewModel.cs
+++ b/EveMarketProphet/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
@@ -87,11 +88,40 @@ namespace EveMarketProphet.ViewModels
             set { SetProperty(ref _showProgressBar, value); }
         }
 
+        private const double MinimumProfitPerJumpDisplay = 15000d;
+
+        private string currentSystemName;
+        public string CurrentSystemName
+        {
+            get { return currentSystemName; }
+            set
+            {
+                if (SetProperty(ref currentSystemName, value))
+                {
+                    findNextRouteCommand?.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        private string destinationSystemName;
+        public string DestinationSystemName
+        {
+            get { return destinationSystemName; }
+            set
+            {
+                if (SetProperty(ref destinationSystemName, value))
+                {
+                    findNextRouteCommand?.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
         public List<RegionSelect> RegionLists { get; set; }
         public RegionSelect SelectedRegionList { get; set; }
 
         public ICommand FetchDataCommand { get; private set; }
         public ICommand FindRoutesCommand { get; private set; }
+        public ICommand FindNextRouteCommand => findNextRouteCommand;
         public ICommand FilterResultsCommand { get; private set; }
         public ICommand OpenMarketWindowCommand { get; private set; }
         public ICommand SetWaypointsCommand { get; private set; }
@@ -109,6 +139,12 @@ namespace EveMarketProphet.ViewModels
         }
 
         private readonly IProgress<int> progress;
+        private CancellationTokenSource routeSearchCancellation;
+        private readonly DelegateCommand findNextRouteCommand;
+        private readonly HashSet<(int StartSystemId, int EndSystemId)> overrideExcludedSystemPairs = new HashSet<(int StartSystemId, int EndSystemId)>();
+        private bool findNextOverrideRequested;
+        private string lastOverrideSystemInput;
+        private string lastDestinationSystemInput;
 
 
         public MainViewModel()
@@ -116,6 +152,7 @@ namespace EveMarketProphet.ViewModels
 
             FetchDataCommand = new DelegateCommand(this.OnFetchData, this.CanFetchData);
             FindRoutesCommand = new DelegateCommand(this.OnFindRoutes);
+            findNextRouteCommand = new DelegateCommand(OnFindNextRoute, CanFindNextRoute);
             FilterResultsCommand = new DelegateCommand<object>(this.OnFilterResults);
             OpenMarketWindowCommand = new DelegateCommand<object>(this.OnOpenMarketWindow);
             SetWaypointsCommand = new DelegateCommand<object>(this.OnSetWaypoints);
@@ -163,6 +200,8 @@ namespace EveMarketProphet.ViewModels
 
             Trips = new ObservableCollection<Trip>(items);
             TripView = CollectionViewSource.GetDefaultView(Trips);
+
+            findNextRouteCommand?.RaiseCanExecuteChanged();
 
             if (TripView != null)
             {
@@ -254,27 +293,186 @@ namespace EveMarketProphet.ViewModels
 
         private async void OnFindRoutes()
         {
-            IsAvailable = false;
-            ShowProgressBar = Visibility.Visible;
-            StatusBarText = "Processing market data ...";
+            var newCts = new CancellationTokenSource();
+            var previousCts = Interlocked.Exchange(ref routeSearchCancellation, newCts);
+            previousCts?.Cancel();
+            previousCts?.Dispose();
 
-            var s = Stopwatch.StartNew();
-            var list = await Task.Run(() => Prophet.FindTradeRoutes());
-            s.Stop();
-            var ts = s.Elapsed;
-            var elapsedTime = $"{ts.Hours:00}:{ts.Minutes:00}:{ts.Seconds:00}.{ts.Milliseconds/10:00}";
-            Debug.WriteLine("Processed market data in " + elapsedTime);
-            StatusBarText = "Processed market data in " + elapsedTime;
-            
-            //Trips = new ObservableCollection<Trip>(EveMarketData.Instance.Trips);
+            var token = newCts.Token;
 
-            if (list != null)
+            var trimmedSystemName = CurrentSystemName?.Trim();
+            var trimmedDestinationName = DestinationSystemName?.Trim();
+            int? overrideSystemId = null;
+            string resolvedSystemName = null;
+            int? destinationSystemId = null;
+            string resolvedDestinationSystemName = null;
+            var useContinuousSearch = false;
+
+            var normalizedSystemInput = trimmedSystemName ?? string.Empty;
+            var normalizedDestinationInput = trimmedDestinationName ?? string.Empty;
+            var overrideInputChanged = !string.Equals(normalizedSystemInput, lastOverrideSystemInput, StringComparison.InvariantCultureIgnoreCase)
+                                       || !string.Equals(normalizedDestinationInput, lastDestinationSystemInput, StringComparison.InvariantCultureIgnoreCase);
+
+            if (!string.IsNullOrWhiteSpace(trimmedSystemName))
             {
-                ApplyTrips(list);
+                var system = Db.Instance.SolarSystems
+                    .FirstOrDefault(s => s.solarSystemName.Equals(trimmedSystemName, StringComparison.InvariantCultureIgnoreCase));
+
+                if (system == null)
+                {
+                    StatusBarText = $"Solar system \"{trimmedSystemName}\" was not found.";
+                    if (Interlocked.CompareExchange(ref routeSearchCancellation, null, newCts) == newCts)
+                    {
+                        newCts.Dispose();
+                    }
+                    return;
+                }
+
+                overrideSystemId = system.solarSystemID;
+                resolvedSystemName = system.solarSystemName;
+                useContinuousSearch = true;
             }
 
-            ShowProgressBar = Visibility.Hidden;
-            IsAvailable = true;
+            if (!string.IsNullOrWhiteSpace(trimmedDestinationName))
+            {
+                var destinationSystem = Db.Instance.SolarSystems
+                    .FirstOrDefault(s => s.solarSystemName.Equals(trimmedDestinationName, StringComparison.InvariantCultureIgnoreCase));
+
+                if (destinationSystem == null)
+                {
+                    StatusBarText = $"Solar system \"{trimmedDestinationName}\" was not found.";
+                    if (Interlocked.CompareExchange(ref routeSearchCancellation, null, newCts) == newCts)
+                    {
+                        newCts.Dispose();
+                    }
+                    return;
+                }
+
+                destinationSystemId = destinationSystem.solarSystemID;
+                resolvedDestinationSystemName = destinationSystem.solarSystemName;
+                useContinuousSearch = true;
+            }
+
+            if (!useContinuousSearch)
+            {
+                overrideExcludedSystemPairs.Clear();
+                lastOverrideSystemInput = null;
+                lastDestinationSystemInput = null;
+            }
+            else if (overrideInputChanged && !findNextOverrideRequested)
+            {
+                overrideExcludedSystemPairs.Clear();
+            }
+
+            if (useContinuousSearch)
+            {
+                lastOverrideSystemInput = normalizedSystemInput;
+                lastDestinationSystemInput = normalizedDestinationInput;
+            }
+
+            IsAvailable = false;
+            ShowProgressBar = Visibility.Visible;
+
+            try
+            {
+                List<Trip> list = null;
+
+                if (useContinuousSearch)
+                {
+                    var stopwatch = Stopwatch.StartNew();
+                    var routeDescriptor = BuildRouteDescription(resolvedSystemName, resolvedDestinationSystemName);
+                    var routeDescriptionSuffix = string.IsNullOrWhiteSpace(routeDescriptor) ? string.Empty : $" {routeDescriptor}";
+                    var searchingMessage = findNextOverrideRequested
+                        ? $"Searching for another profitable route{routeDescriptionSuffix} (ignoring settings)..."
+                        : $"Searching for profitable routes{routeDescriptionSuffix} (ignoring settings)...";
+                    StatusBarText = searchingMessage;
+
+                    var options = new ProphetSearchOptions
+                    {
+                        StartSystemIdOverride = overrideSystemId,
+                        DestinationSystemIdFilter = destinationSystemId,
+                        IgnoreSettings = true
+                    };
+
+                    options.ExcludedSystemPairs = new HashSet<(int StartSystemId, int EndSystemId)>(overrideExcludedSystemPairs);
+                    options.MinimumProfitPerJumpOverride = MinimumProfitPerJumpDisplay;
+
+                    while (!token.IsCancellationRequested)
+                    {
+                        list = await Task.Run(() => Prophet.FindTradeRoutes(options), token);
+
+                        if (list == null)
+                        {
+                            StatusBarText = "Market data is unavailable. Fetch data before searching for routes.";
+                            break;
+                        }
+
+                        if (list.Count > 0)
+                        {
+                            stopwatch.Stop();
+                            var ts = stopwatch.Elapsed;
+                            var elapsedTime = $"{ts.Hours:00}:{ts.Minutes:00}:{ts.Seconds:00}.{ts.Milliseconds / 10:00}";
+                            var foundMessage = findNextOverrideRequested
+                                ? $"Found an alternative profitable route{routeDescriptionSuffix} in {elapsedTime}."
+                                : $"Found a profitable route{routeDescriptionSuffix} in {elapsedTime}.";
+                            StatusBarText = foundMessage;
+                            break;
+                        }
+
+                        StatusBarText = findNextOverrideRequested
+                            ? $"No additional profitable routes{routeDescriptionSuffix} yet. Retrying..."
+                            : $"No profitable routes{routeDescriptionSuffix} yet. Retrying...";
+                        await Task.Delay(TimeSpan.FromSeconds(10), token);
+                    }
+                }
+                else
+                {
+                    StatusBarText = "Processing market data ...";
+                    var stopwatch = Stopwatch.StartNew();
+                    list = await Task.Run(() => Prophet.FindTradeRoutes(), token);
+                    stopwatch.Stop();
+                    var ts = stopwatch.Elapsed;
+                    var elapsedTime = $"{ts.Hours:00}:{ts.Minutes:00}:{ts.Seconds:00}.{ts.Milliseconds / 10:00}";
+                    Debug.WriteLine("Processed market data in " + elapsedTime);
+                    StatusBarText = "Processed market data in " + elapsedTime;
+                }
+
+                if (!token.IsCancellationRequested)
+                {
+                    if (list != null && list.Count > 0)
+                    {
+                        ApplyTrips(list);
+                    }
+                    else if (!useContinuousSearch && list != null)
+                    {
+                        StatusBarText = "No profitable routes found.";
+                    }
+                    else if (useContinuousSearch && list != null && list.Count == 0)
+                    {
+                        var routeDescriptor = BuildRouteDescription(resolvedSystemName, resolvedDestinationSystemName);
+                        var routeDescriptionSuffix = string.IsNullOrWhiteSpace(routeDescriptor) ? string.Empty : $" {routeDescriptor}";
+                        StatusBarText = findNextOverrideRequested
+                            ? $"Unable to find another profitable route{routeDescriptionSuffix} right now."
+                            : $"Unable to find a profitable route{routeDescriptionSuffix}.";
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                StatusBarText = "Route search canceled.";
+            }
+            finally
+            {
+                ShowProgressBar = Visibility.Hidden;
+                IsAvailable = true;
+                findNextOverrideRequested = false;
+                findNextRouteCommand?.RaiseCanExecuteChanged();
+
+                if (Interlocked.CompareExchange(ref routeSearchCancellation, null, newCts) == newCts)
+                {
+                    newCts.Dispose();
+                }
+            }
         }
 
         private int FilterSystemStartId { get; set; }
@@ -284,6 +482,9 @@ namespace EveMarketProphet.ViewModels
         private bool TripFilter(object sender)
         {
             if (!(sender is Trip trip))
+                return false;
+
+            if (trip.ProfitPerJump < MinimumProfitPerJumpDisplay)
                 return false;
 
             if (hasSystemFilter && !MatchesSystemPair(trip))
@@ -383,6 +584,46 @@ namespace EveMarketProphet.ViewModels
             }
 
             Auth.Instance.SetWaypoints(systemId, clearOtherWaypoints);
+        }
+
+        private bool CanFindNextRoute()
+        {
+            return Trips != null && Trips.Count > 0 && (!string.IsNullOrWhiteSpace(CurrentSystemName) || !string.IsNullOrWhiteSpace(DestinationSystemName));
+        }
+
+        private void OnFindNextRoute()
+        {
+            if (Trips == null || Trips.Count == 0)
+                return;
+
+            var firstTrip = Trips.FirstOrDefault();
+            var firstTransaction = firstTrip?.Transactions?.FirstOrDefault();
+            if (firstTransaction == null)
+                return;
+
+            overrideExcludedSystemPairs.Add((firstTransaction.StartSystemId, firstTransaction.EndSystemId));
+            findNextOverrideRequested = true;
+            OnFindRoutes();
+        }
+
+        private static string BuildRouteDescription(string startSystemName, string destinationSystemName)
+        {
+            if (!string.IsNullOrWhiteSpace(startSystemName) && !string.IsNullOrWhiteSpace(destinationSystemName))
+            {
+                return $"from {startSystemName} to {destinationSystemName}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(startSystemName))
+            {
+                return $"from {startSystemName}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(destinationSystemName))
+            {
+                return $"to {destinationSystemName}";
+            }
+
+            return "";
         }
     }
 }

--- a/EveMarketProphet/Views/MainView.xaml
+++ b/EveMarketProphet/Views/MainView.xaml
@@ -145,6 +145,9 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
                             <Button x:Name="fetchDataButton" Grid.Column="0" Grid.Row="0" Command="{Binding FetchDataCommand}" MinWidth="130">
@@ -156,14 +159,47 @@
 
                             <ComboBox x:Name="regionSelect" Grid.Column="1" Grid.Row="0" ItemsSource="{Binding RegionLists}" SelectedValue="{Binding SelectedRegionList}" SelectedIndex="0" DisplayMemberPath="Label" Margin="16,0,0,0" Width="160" IsReadOnly="True" Foreground="Black" Background="White"/>
 
-                            <Button x:Name="findRoutesButton" Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Command="{Binding FindRoutesCommand}" Margin="0,16,0,0" MinWidth="160" Background="{StaticResource AccentColor}" Foreground="{StaticResource ForegroundColor}">
+                            <StackPanel Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Margin="0,16,0,0">
+                                <TextBlock Text="Current System Override" Foreground="#FF9AA3B7" Margin="0,0,0,4" />
+                                <Grid>
+                                    <TextBox Text="{Binding CurrentSystemName, UpdateSourceTrigger=PropertyChanged}" MinWidth="160"/>
+                                    <TextBlock Text="Enter solar system name..." Margin="12,0,0,0" VerticalAlignment="Center" Foreground="#FF596279" IsHitTestVisible="False">
+                                        <TextBlock.Visibility>
+                                            <Binding Path="CurrentSystemName" Converter="{StaticResource EmptyStringToVisibility}" />
+                                        </TextBlock.Visibility>
+                                    </TextBlock>
+                                </Grid>
+                                <TextBlock Text="Ignores settings and keeps searching until a profitable route is found." Foreground="#FF9AA3B7" FontSize="11" Margin="0,4,0,0" />
+                            </StackPanel>
+
+                            <StackPanel Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,12,0,0">
+                                <TextBlock Text="Destination System (Optional)" Foreground="#FF9AA3B7" Margin="0,0,0,4" />
+                                <Grid>
+                                    <TextBox Text="{Binding DestinationSystemName, UpdateSourceTrigger=PropertyChanged}" MinWidth="160"/>
+                                    <TextBlock Text="Enter target solar system..." Margin="12,0,0,0" VerticalAlignment="Center" Foreground="#FF596279" IsHitTestVisible="False">
+                                        <TextBlock.Visibility>
+                                            <Binding Path="DestinationSystemName" Converter="{StaticResource EmptyStringToVisibility}" />
+                                        </TextBlock.Visibility>
+                                    </TextBlock>
+                                </Grid>
+                                <TextBlock Text="Only show routes that start from the override system and arrive here." Foreground="#FF9AA3B7" FontSize="11" Margin="0,4,0,0" />
+                            </StackPanel>
+
+                            <Button x:Name="findRoutesButton" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="2" Command="{Binding FindRoutesCommand}" Margin="0,16,0,0" MinWidth="160" Background="{StaticResource AccentColor}" Foreground="{StaticResource ForegroundColor}">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="&#xE14C;" FontFamily="Segoe UI Symbol" Margin="0,0,8,0" />
                                     <TextBlock Text="Find Routes" />
                                 </StackPanel>
                             </Button>
 
-                            <Button x:Name="filterButton" Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" Command="{Binding ClearFiltersCommand}" Margin="0,12,0,0" MinWidth="160">
+                            <Button Grid.Column="0" Grid.Row="4" Grid.ColumnSpan="2" Command="{Binding FindNextRouteCommand}" Margin="0,12,0,0" MinWidth="160">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="&#xE149;" FontFamily="Segoe UI Symbol" Margin="0,0,8,0" />
+                                    <TextBlock Text="Search Next Route" />
+                                </StackPanel>
+                            </Button>
+
+                            <Button x:Name="filterButton" Grid.Column="0" Grid.Row="5" Grid.ColumnSpan="2" Command="{Binding ClearFiltersCommand}" Margin="0,12,0,0" MinWidth="160">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="&#xE117;" FontFamily="Segoe UI Symbol" Margin="0,0,8,0" />
                                     <TextBlock Text="Reset Filters" />


### PR DESCRIPTION
## Summary
- filter sell/buy orders by override start, destination, and excluded pairs before creating transactions to reduce the workload during continuous searches
- reuse grouped transactions when assembling trips so each type processes only its relevant orders once

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e847aeb5a483278c6ee3cb817f2275