### PR TITLE
Add multi-leg journey planner

### DIFF
--- a/EveMarketProphet/App.xaml
+++ b/EveMarketProphet/App.xaml
@@ -10,6 +10,7 @@
                <ResourceDictionary Source="Resources/Colors.xaml"></ResourceDictionary>
                <ResourceDictionary Source="Resources/Styles.xaml"></ResourceDictionary>
                 <ResourceDictionary Source="Resources/TripTemplate.xaml"></ResourceDictionary>
+                <ResourceDictionary Source="Resources/JourneyTemplate.xaml"></ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
        </ResourceDictionary>
     </Application.Resources>

--- a/EveMarketProphet/Converters/IndexToDisplayConverter.cs
+++ b/EveMarketProphet/Converters/IndexToDisplayConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace EveMarketProphet.Converters
+{
+    public class IndexToDisplayConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is int index)
+            {
+                return (index + 1).ToString(culture);
+            }
+
+            return "1";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/EveMarketProphet/EveMarketProphet.csproj
+++ b/EveMarketProphet/EveMarketProphet.csproj
@@ -366,8 +366,11 @@
     <Compile Include="Services\Prophet.cs" />
     <Compile Include="Converters\SecurityColorConverter.cs" />
     <Compile Include="Converters\StringNullOrEmptyToVisibilityConverter.cs" />
+    <Compile Include="Converters\IndexToDisplayConverter.cs" />
     <Compile Include="Models\Transaction.cs" />
     <Compile Include="Models\Trip.cs" />
+    <Compile Include="Models\Journey.cs" />
+    <Compile Include="Models\RouteSearchResult.cs" />
     <Compile Include="Utils\SecurityUtils.cs" />
     <Compile Include="Extensions\SettingsBindingExtension.cs" />
     <Compile Include="Views\SettingsView.xaml.cs">
@@ -410,6 +413,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Resources\TripTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Resources\JourneyTemplate.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/EveMarketProphet/Models/Journey.cs
+++ b/EveMarketProphet/Models/Journey.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using EveMarketProphet.Services;
+
+namespace EveMarketProphet.Models
+{
+    public class Journey
+    {
+        public List<Trip> Legs { get; set; } = new List<Trip>();
+        public List<int> Waypoints { get; set; } = new List<int>();
+        public List<SolarSystem> SecurityWaypoints { get; set; } = new List<SolarSystem>();
+
+        public double TotalProfit { get; set; }
+        public double TotalCost { get; set; }
+        public double TotalWeight { get; set; }
+        public double MaxCost { get; set; }
+        public double MaxWeight { get; set; }
+        public int TotalJumps { get; set; }
+        public double ProfitPerJump { get; set; }
+
+        public int LegCount => Legs?.Count ?? 0;
+        public Trip FirstLeg => Legs?.FirstOrDefault();
+        public Trip LastLeg => Legs?.LastOrDefault();
+        public string StartStationName => FirstLeg?.StartStationName;
+        public string EndStationName => LastLeg?.EndStationName;
+    }
+}

--- a/EveMarketProphet/Models/RouteSearchResult.cs
+++ b/EveMarketProphet/Models/RouteSearchResult.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace EveMarketProphet.Models
+{
+    public class RouteSearchResult
+    {
+        public List<Trip> Trips { get; set; } = new List<Trip>();
+        public List<Journey> Journeys { get; set; } = new List<Journey>();
+    }
+}

--- a/EveMarketProphet/Models/Trip.cs
+++ b/EveMarketProphet/Models/Trip.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using EveMarketProphet.Services;
 
 namespace EveMarketProphet.Models
@@ -13,5 +14,17 @@ namespace EveMarketProphet.Models
         public double ProfitPerJump { get; set; }
         public double Cost { get; set; }
         public double Weight { get; set; }
+
+        public Transaction PrimaryTransaction => Transactions?.FirstOrDefault();
+
+        public int StartSystemId => PrimaryTransaction?.StartSystemId ?? 0;
+        public int EndSystemId => PrimaryTransaction?.EndSystemId ?? 0;
+        public long StartStationId => PrimaryTransaction?.StartStationId ?? 0;
+        public long EndStationId => PrimaryTransaction?.EndStationId ?? 0;
+        public string StartStationName => PrimaryTransaction?.SellOrder?.StationName;
+        public string EndStationName => PrimaryTransaction?.BuyOrder?.StationName;
+
+        public IReadOnlyList<int> TradeWaypoints => PrimaryTransaction?.Waypoints;
+        public int TradeJumps => PrimaryTransaction?.Jumps ?? 0;
     }
 }

--- a/EveMarketProphet/Resources/JourneyTemplate.xaml
+++ b/EveMarketProphet/Resources/JourneyTemplate.xaml
@@ -1,0 +1,146 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:EveMarketProphet.Converters">
+
+    <converters:SecurityColorConverter x:Key="SecConverter"/>
+    <converters:IndexToDisplayConverter x:Key="IndexToDisplayConverter"/>
+
+    <DataTemplate x:Key="JourneyTemplate">
+        <Border Margin="0" Padding="20" Background="{StaticResource SurfaceAltColor}" CornerRadius="18" BorderBrush="{StaticResource SubtleBorderColor}" BorderThickness="1">
+            <Border.Effect>
+                <DropShadowEffect BlurRadius="18" ShadowDepth="0" Opacity="0.35" Color="#CC000000" />
+            </Border.Effect>
+            <StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock FontSize="18" FontWeight="SemiBold" Foreground="{StaticResource ForegroundColor}">
+                            <TextBlock.Text>
+                                <MultiBinding StringFormat="{}{0} → {1}">
+                                    <Binding Path="StartStationName" />
+                                    <Binding Path="EndStationName" />
+                                </MultiBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
+                        <TextBlock Text="{Binding LegCount, StringFormat=Legs: {0}}" Foreground="#FF9AA3B7" Margin="0,4,0,0" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Command="{Binding DataContext.FilterResultsCommand, ElementName=JourneyList}"
+                                CommandParameter="{Binding Legs[0].Transactions[0]}"
+                                Margin="0,0,12,0"
+                                MinWidth="110"
+                                Background="{StaticResource AccentColor}"
+                                Foreground="{StaticResource BackgroundColor}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE16E;" FontFamily="Segoe UI Symbol" Margin="0,0,8,0" />
+                                <TextBlock Text="Filter Legs" />
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding DataContext.SetWaypointsCommand, ElementName=JourneyList}"
+                                CommandParameter="{Binding Legs[0].StartSystemId}"
+                                MinWidth="130"
+                                Background="{StaticResource SurfaceColor}"
+                                Foreground="{StaticResource AccentColor}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE128;" FontFamily="Segoe UI Symbol" Margin="0,0,8,0" />
+                                <TextBlock Text="Set First Leg" />
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+
+                <Grid Margin="0,16,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0">
+                        <ItemsControl ItemsSource="{Binding SecurityWaypoints}" x:Name="JourneyWaypointDots" HorizontalAlignment="Left">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Width="10" Height="10" Background="{Binding security, Converter={StaticResource SecConverter}}" CornerRadius="5" Margin="4,0,0,0">
+                                        <Border.ToolTip>
+                                            <ToolTip>
+                                                <StackPanel Orientation="Horizontal" Margin="0">
+                                                    <TextBlock Text="{Binding solarSystemName}" />
+                                                    <TextBlock Margin="6,0,0,0" Text="{Binding security,StringFormat={}{0:N1}}" Foreground="{Binding security, Converter={StaticResource SecConverter}}" />
+                                                </StackPanel>
+                                            </ToolTip>
+                                        </Border.ToolTip>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <TextBlock Text="{Binding TotalJumps, StringFormat={}{0} Jumps}" Margin="0,10,0,0" Foreground="#FF9AA3B7" FontWeight="SemiBold"/>
+                    </StackPanel>
+
+                    <UniformGrid Grid.Column="1" Columns="2" Rows="2" HorizontalAlignment="Right">
+                        <Border Background="{StaticResource CardPositiveColor}" CornerRadius="10" Padding="12" Margin="12,0,0,12" ToolTip="Total Profit">
+                            <StackPanel>
+                                <TextBlock Text="Profit" Foreground="{StaticResource ForegroundColor}" FontSize="12" />
+                                <TextBlock Text="{Binding TotalProfit, StringFormat={}{0:N0} ISK}" Foreground="{StaticResource ForegroundColor}" FontSize="16" FontWeight="SemiBold" />
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource CardNeutralColor}" CornerRadius="10" Padding="12" Margin="12,0,0,12" ToolTip="Profit per Jump">
+                            <StackPanel>
+                                <TextBlock Text="Profit / Jump" Foreground="{StaticResource AccentColor}" FontSize="12" />
+                                <TextBlock Text="{Binding ProfitPerJump, StringFormat={}{0:N0} ISK}" Foreground="{StaticResource ForegroundColor}" FontSize="16" FontWeight="SemiBold" />
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource CardNeutralColor}" CornerRadius="10" Padding="12" Margin="12,0,0,0" ToolTip="Max Capital Required">
+                            <StackPanel>
+                                <TextBlock Text="Max Cost" Foreground="#FF9AA3B7" FontSize="12" />
+                                <TextBlock Text="{Binding MaxCost, StringFormat={}{0:N0} ISK}" Foreground="{StaticResource ForegroundColor}" FontSize="16" FontWeight="SemiBold" />
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource CardNeutralColor}" CornerRadius="10" Padding="12" Margin="12,0,0,0" ToolTip="Max Cargo Requirement">
+                            <StackPanel>
+                                <TextBlock Text="Max Cargo" Foreground="{StaticResource AccentColor}" FontSize="12" />
+                                <TextBlock Text="{Binding MaxWeight, StringFormat={}{0:N2} m³}" Foreground="{StaticResource ForegroundColor}" FontSize="16" FontWeight="SemiBold" />
+                            </StackPanel>
+                        </Border>
+                    </UniformGrid>
+                </Grid>
+
+                <ItemsControl ItemsSource="{Binding Legs}" Margin="0,24,0,0" AlternationCount="100">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Vertical" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Margin="0,12,0,0" Padding="16" Background="{StaticResource SurfaceColor}" CornerRadius="14" BorderBrush="{StaticResource SubtleBorderColor}" BorderThickness="1">
+                                <StackPanel>
+                                    <TextBlock FontWeight="SemiBold" Foreground="{StaticResource ForegroundColor}">
+                                        <Run Text="Leg " />
+                                        <Run Text="{Binding RelativeSource={RelativeSource AncestorType=ContentPresenter}, Path=(ItemsControl.AlternationIndex), Converter={StaticResource IndexToDisplayConverter}}" />
+                                        <Run Text=": " />
+                                        <Run Text="{Binding StartStationName}" />
+                                        <Run Text=" → " />
+                                        <Run Text="{Binding EndStationName}" />
+                                    </TextBlock>
+                                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                        <TextBlock Text="{Binding Profit, StringFormat=Profit: {0:N0} ISK}" Foreground="{StaticResource ForegroundColor}" />
+                                        <TextBlock Text="{Binding ProfitPerJump, StringFormat=Per Jump: {0:N0} ISK}" Foreground="#FF9AA3B7" Margin="16,0,0,0" />
+                                        <TextBlock Text="{Binding TradeJumps, StringFormat=Route: {0} jumps}" Foreground="#FF9AA3B7" Margin="16,0,0,0" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+    </DataTemplate>
+
+</ResourceDictionary>

--- a/EveMarketProphet/Services/Prophet.cs
+++ b/EveMarketProphet/Services/Prophet.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using EveMarketProphet.Models;
 using EveMarketProphet.Properties;
@@ -39,7 +40,7 @@ namespace EveMarketProphet.Services
             return route;
         }
 
-        public static List<Trip> FindTradeRoutes()
+        public static RouteSearchResult FindTradeRoutes()
         {
             if (Market.Instance.OrdersByType == null) return null;
             if (Market.Instance.OrdersByType.Count == 0) return null;
@@ -270,7 +271,179 @@ namespace EveMarketProphet.Services
             });
 
             var orderedTrips = trips.ToList();
-            return orderedTrips.OrderByDescending(x => x.ProfitPerJump).ToList();
+            orderedTrips = orderedTrips.OrderByDescending(x => x.ProfitPerJump).ToList();
+
+            var journeys = BuildJourneys(orderedTrips, solarSystemsById);
+
+            return new RouteSearchResult
+            {
+                Trips = orderedTrips,
+                Journeys = journeys
+            };
+        }
+
+        private static List<Journey> BuildJourneys(List<Trip> trips, IDictionary<int, SolarSystem> solarSystemsById)
+        {
+            const int maxLegs = 3;
+            var journeys = new List<Journey>();
+
+            if (trips == null || trips.Count == 0)
+                return journeys;
+
+            var tripsByStart = trips
+                .Where(t => t != null)
+                .GroupBy(t => t.StartSystemId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            var seen = new HashSet<string>();
+
+            foreach (var trip in trips)
+            {
+                if (trip == null)
+                    continue;
+
+                var path = new List<Trip> { trip };
+                ExploreJourneys(path, tripsByStart, journeys, seen, solarSystemsById, maxLegs);
+            }
+
+            return journeys
+                .OrderByDescending(j => j.ProfitPerJump)
+                .ThenByDescending(j => j.TotalProfit)
+                .ToList();
+        }
+
+        private static void ExploreJourneys(List<Trip> path,
+            IDictionary<int, List<Trip>> tripsByStart,
+            List<Journey> journeys,
+            HashSet<string> seen,
+            IDictionary<int, SolarSystem> solarSystemsById,
+            int maxLegs)
+        {
+            if (path.Count >= 2)
+            {
+                var key = string.Join("|", path.Select(p => RuntimeHelpers.GetHashCode(p)));
+                if (!seen.Contains(key))
+                {
+                    var journey = CreateJourney(path, solarSystemsById);
+                    if (journey != null)
+                    {
+                        journeys.Add(journey);
+                        seen.Add(key);
+                    }
+                }
+            }
+
+            if (path.Count >= maxLegs)
+                return;
+
+            var current = path[path.Count - 1];
+            if (!tripsByStart.TryGetValue(current.EndSystemId, out var nextOptions))
+                return;
+
+            foreach (var next in nextOptions)
+            {
+                if (path.Contains(next))
+                    continue;
+
+                var transition = GetRoute(current.EndSystemId, next.StartSystemId);
+                if (transition == null)
+                    continue;
+
+                path.Add(next);
+                ExploreJourneys(path, tripsByStart, journeys, seen, solarSystemsById, maxLegs);
+                path.RemoveAt(path.Count - 1);
+            }
+        }
+
+        private static Journey CreateJourney(IEnumerable<Trip> legs, IDictionary<int, SolarSystem> solarSystemsById)
+        {
+            var legList = legs?.ToList();
+            if (legList == null || legList.Count < 2)
+                return null;
+
+            var firstLeg = legList[0];
+
+            if (firstLeg.Waypoints == null || firstLeg.TradeWaypoints == null)
+                return null;
+
+            var aggregatedSystemIds = new List<int>();
+            var aggregatedSecurity = new List<SolarSystem>();
+            var totalJumps = 0;
+
+            AppendRoute(firstLeg.Waypoints, aggregatedSystemIds, aggregatedSecurity, solarSystemsById, ref totalJumps);
+            AppendRoute(firstLeg.TradeWaypoints, aggregatedSystemIds, aggregatedSecurity, solarSystemsById, ref totalJumps, firstLeg.TradeJumps);
+
+            for (var i = 1; i < legList.Count; i++)
+            {
+                var previous = legList[i - 1];
+                var current = legList[i];
+
+                var transition = GetRoute(previous.EndSystemId, current.StartSystemId);
+                if (transition == null)
+                    return null;
+
+                AppendRoute(transition, aggregatedSystemIds, aggregatedSecurity, solarSystemsById, ref totalJumps);
+                AppendRoute(current.TradeWaypoints, aggregatedSystemIds, aggregatedSecurity, solarSystemsById, ref totalJumps, current.TradeJumps);
+            }
+
+            var totalProfit = legList.Sum(l => l.Profit);
+            var totalCost = legList.Sum(l => l.Cost);
+            var totalWeight = legList.Sum(l => l.Weight);
+            var maxCost = legList.Max(l => l.Cost);
+            var maxWeight = legList.Max(l => l.Weight);
+            var profitPerJump = totalJumps > 0 ? totalProfit / totalJumps : totalProfit;
+
+            return new Journey
+            {
+                Legs = new List<Trip>(legList),
+                Waypoints = aggregatedSystemIds,
+                SecurityWaypoints = aggregatedSecurity,
+                TotalProfit = totalProfit,
+                TotalCost = totalCost,
+                TotalWeight = totalWeight,
+                MaxCost = maxCost,
+                MaxWeight = maxWeight,
+                TotalJumps = totalJumps,
+                ProfitPerJump = profitPerJump
+            };
+        }
+
+        private static void AppendRoute(IEnumerable<int> systemIds,
+            ICollection<int> aggregatedSystemIds,
+            ICollection<SolarSystem> aggregatedSecurity,
+            IDictionary<int, SolarSystem> solarSystemsById,
+            ref int totalJumps,
+            int? explicitJumpCount = null)
+        {
+            if (systemIds == null)
+            {
+                if (explicitJumpCount.HasValue)
+                {
+                    totalJumps += explicitJumpCount.Value;
+                }
+                return;
+            }
+
+            var ids = systemIds.ToList();
+            if (ids.Count == 0)
+            {
+                if (explicitJumpCount.HasValue)
+                {
+                    totalJumps += explicitJumpCount.Value;
+                }
+                return;
+            }
+
+            foreach (var id in ids)
+            {
+                aggregatedSystemIds.Add(id);
+                if (solarSystemsById.TryGetValue(id, out var system))
+                {
+                    aggregatedSecurity.Add(system);
+                }
+            }
+
+            totalJumps += explicitJumpCount ?? ids.Count;
         }
     }
 }

--- a/EveMarketProphet/Views/MainView.xaml
+++ b/EveMarketProphet/Views/MainView.xaml
@@ -207,23 +207,46 @@
             </StatusBar>
         </Border>
 
-        <ListView x:Name="listBoxResults"
-                  Grid.IsSharedSizeScope="True"
-                  ItemsSource="{Binding TripView, Mode=OneWay}"
-                  ItemTemplate="{StaticResource TripTemplate}"
-                  HorizontalContentAlignment="Stretch"
-                  ScrollViewer.CanContentScroll="False"
-                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                  Background="Transparent"
-                  BorderThickness="0"
-                  Margin="32"
-                  Padding="0">
-            <ListView.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <StackPanel Orientation="Vertical" />
-                </ItemsPanelTemplate>
-            </ListView.ItemsPanel>
-        </ListView>
+        <TabControl Margin="32" Background="Transparent" BorderThickness="0">
+            <TabItem Header="Trips">
+                <ListView x:Name="listBoxResults"
+                          Grid.IsSharedSizeScope="True"
+                          ItemsSource="{Binding TripView, Mode=OneWay}"
+                          ItemTemplate="{StaticResource TripTemplate}"
+                          HorizontalContentAlignment="Stretch"
+                          ScrollViewer.CanContentScroll="False"
+                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                          Background="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          Margin="0,16,0,0">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Vertical" />
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
+                </ListView>
+            </TabItem>
+            <TabItem Header="Journeys">
+                <ListView x:Name="JourneyList"
+                          Grid.IsSharedSizeScope="True"
+                          ItemsSource="{Binding JourneyView, Mode=OneWay}"
+                          ItemTemplate="{StaticResource JourneyTemplate}"
+                          HorizontalContentAlignment="Stretch"
+                          ScrollViewer.CanContentScroll="False"
+                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                          Background="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          Margin="0,16,0,0">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Vertical" />
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
+                </ListView>
+            </TabItem>
+        </TabControl>
 
     </DockPanel>
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ Keep in mind that your ingame settings for safer/faster routes still applies, so
 The **Clear Filter** button in the toolbar will remove the filtering.
 
 
+## Journey Planner
+
+A journey chains multiple trips together into a single plan, starting from your current location and visiting several profitable destinations in sequence.
+
+Open the **Journeys** tab to review the suggested multi-leg plans. Each journey shows the overall profit, profit per jump, maximum investment and cargo required at any stage, plus every leg with its individual metrics. Use the built-in filter and waypoint buttons to quickly focus on a particular journey or set the first set of waypoints in-game.
+
+Journeys reuse the same cargo and capital settings as individual trips, so every leg remains flyable with your configured limits while offering a longer trading circuit.
+
+
 ## Transaction
 
 ![tx](Docs/Images/tx.png)


### PR DESCRIPTION
## Summary
- add journey aggregation models and extend the prophet service to assemble multi-leg trading routes
- expose journeys in the view-model and surface them in the UI via a new Journeys tab and template
- document the journey planner and add supporting resources and converters

## Testing
- dotnet test *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e85efb23c88327ba418e820420bc94