### PR TITLE
Prevent crash when opening Journeys tab with empty trips

### DIFF
--- a/EveMarketProphet/EveMarketProphet.csproj
+++ b/EveMarketProphet/EveMarketProphet.csproj
@@ -364,6 +364,7 @@
     <Compile Include="Services\Auth.cs" />
     <Compile Include="Utils\ParallelUtils.cs" />
     <Compile Include="Services\Prophet.cs" />
+    <Compile Include="Services\DiagnosticsLogger.cs" />
     <Compile Include="Converters\SecurityColorConverter.cs" />
     <Compile Include="Converters\StringNullOrEmptyToVisibilityConverter.cs" />
     <Compile Include="Converters\IndexToDisplayConverter.cs" />

--- a/EveMarketProphet/Models/Transaction.cs
+++ b/EveMarketProphet/Models/Transaction.cs
@@ -11,17 +11,17 @@ namespace EveMarketProphet.Models
         public double Profit { get; private set; }
         public int Quantity { get; private set; }
 
-        public long StartStationId => SellOrder.StationId; 
-        public long EndStationId => BuyOrder.StationId;
-        public int StartSystemId => SellOrder.SystemId;
-        public int EndSystemId => BuyOrder.SystemId;
-        public int TypeId => SellOrder.TypeId;
-        public string TypeName => SellOrder.TypeName;
-        public double TypeVolume => SellOrder.TypeVolume;
-        public string Icon => $"https://image.eveonline.com/Type/{TypeId}_64.png";
+        public long StartStationId => SellOrder?.StationId ?? 0;
+        public long EndStationId => BuyOrder?.StationId ?? 0;
+        public int StartSystemId => SellOrder?.SystemId ?? 0;
+        public int EndSystemId => BuyOrder?.SystemId ?? 0;
+        public int TypeId => SellOrder?.TypeId ?? BuyOrder?.TypeId ?? 0;
+        public string TypeName => SellOrder?.TypeName ?? BuyOrder?.TypeName;
+        public double TypeVolume => SellOrder?.TypeVolume ?? BuyOrder?.TypeVolume ?? 0;
+        public string Icon => TypeId > 0 ? $"https://image.eveonline.com/Type/{TypeId}_64.png" : string.Empty;
 
-        public long Cost => Quantity * SellOrder.Price;
-        public double Weight => Quantity * SellOrder.TypeVolume;
+        public long Cost => SellOrder != null ? Quantity * SellOrder.Price : 0;
+        public double Weight => SellOrder != null ? Quantity * SellOrder.TypeVolume : 0;
 
         public List<int> Waypoints { get; set; }
         public double ProfitPerJump { get; set; } //{ get { return Waypoints.Count > 0 ? Profit / Waypoints.Count : Profit; } }

--- a/EveMarketProphet/Resources/JourneyTemplate.xaml
+++ b/EveMarketProphet/Resources/JourneyTemplate.xaml
@@ -29,7 +29,7 @@
                     </StackPanel>
                     <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
                         <Button Command="{Binding DataContext.FilterResultsCommand, ElementName=JourneyList}"
-                                CommandParameter="{Binding Legs[0].Transactions[0]}"
+                                CommandParameter="{Binding FirstLeg.PrimaryTransaction}"
                                 Margin="0,0,12,0"
                                 MinWidth="110"
                                 Background="{StaticResource AccentColor}"
@@ -40,7 +40,7 @@
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding DataContext.SetWaypointsCommand, ElementName=JourneyList}"
-                                CommandParameter="{Binding Legs[0].StartSystemId}"
+                                CommandParameter="{Binding FirstLeg.StartSystemId}"
                                 MinWidth="130"
                                 Background="{StaticResource SurfaceColor}"
                                 Foreground="{StaticResource AccentColor}">

--- a/EveMarketProphet/Services/DiagnosticsLogger.cs
+++ b/EveMarketProphet/Services/DiagnosticsLogger.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace EveMarketProphet.Services
+{
+    public static class DiagnosticsLogger
+    {
+        private static readonly object Gate = new object();
+        private static readonly string LogDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "EveMarketProphet");
+        private static readonly string LogFilePath = Path.Combine(LogDirectory, "diagnostics.log");
+
+        public static string FilePath => LogFilePath;
+
+        public static void Log(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            var timestampedMessage = $"{DateTime.UtcNow:O} {message}";
+
+            try
+            {
+                lock (Gate)
+                {
+                    Directory.CreateDirectory(LogDirectory);
+                    File.AppendAllText(LogFilePath, timestampedMessage + Environment.NewLine, Encoding.UTF8);
+                }
+            }
+            catch
+            {
+                // Swallow all exceptions: diagnostics should never crash the UI.
+            }
+        }
+
+        public static void LogException(string message, Exception ex)
+        {
+            Log($"{message}: {ex}");
+        }
+    }
+}

--- a/EveMarketProphet/ViewModels/MainViewModel.cs
+++ b/EveMarketProphet/ViewModels/MainViewModel.cs
@@ -393,8 +393,17 @@ namespace EveMarketProphet.ViewModels
             if (!(sender is Transaction tx))
                 return;
 
-            FilterSystemStartId = tx.StartSystemId;
-            FilterSystemEndId = tx.EndSystemId;
+            if (tx.SellOrder == null || tx.BuyOrder == null)
+                return;
+
+            var startSystemId = tx.StartSystemId;
+            var endSystemId = tx.EndSystemId;
+
+            if (startSystemId == 0 || endSystemId == 0)
+                return;
+
+            FilterSystemStartId = startSystemId;
+            FilterSystemEndId = endSystemId;
             hasSystemFilter = true;
 
             TripView?.Refresh();

--- a/EveMarketProphet/ViewModels/MainViewModel.cs
+++ b/EveMarketProphet/ViewModels/MainViewModel.cs
@@ -349,7 +349,10 @@ namespace EveMarketProphet.ViewModels
 
         private bool MatchesSystemPair(Trip trip)
         {
-            var tx = trip.Transactions.First();
+            var tx = trip.Transactions?.FirstOrDefault();
+
+            if (tx == null)
+                return false;
 
             if (tx.StartSystemId == FilterSystemStartId && tx.EndSystemId == FilterSystemEndId) return true;
 

--- a/EveMarketProphet/ViewModels/MainViewModel.cs
+++ b/EveMarketProphet/ViewModels/MainViewModel.cs
@@ -365,7 +365,7 @@ namespace EveMarketProphet.ViewModels
 
             var tx = trip.Transactions.FirstOrDefault();
 
-            if (tx?.SellOrder == null || tx.BuyOrder == null)
+            if (tx?.SellOrder == null || tx?.BuyOrder == null)
                 return false;
 
             if (tx.StartSystemId == FilterSystemStartId && tx.EndSystemId == FilterSystemEndId) return true;


### PR DESCRIPTION
## Summary
- avoid dereferencing missing transactions when evaluating journey filters
- ensure journeys without transaction data no longer crash the view when filtering

## Testing
- Not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8660f6cec8327be6190d67f339b2b